### PR TITLE
Adds a next branch that makes koa-websocket work with koa-router 7.x

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,4 +2,4 @@ machine:
   pre:
     - curl https://raw.githubusercontent.com/creationix/nvm/v0.23.3/install.sh | bash
   node:
-    version: iojs-2.0.1
+    version: 6.1.0

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ KoaWebSocketServer.prototype.onConnection = function(socket) {
   context.websocket = socket;
   context.path = url.parse(socket.upgradeReq.url).pathname;
 
-  fn.bind(context).call().catch(function(err) {
+  fn(context).catch(function(err) {
     debug(err);
   });
 };

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "ws": "^1.1.0"
   },
   "devDependencies": {
-    "koa": "^1.0.0",
-    "koa-route": "^2.4.0",
+    "koa": "^2.0.0-alpha.7",
+    "koa-route": "^3.2.0",
     "mocha": "^2.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "co": "^4.4.0",
     "debug": "^2.1.2",
-    "koa-compose": "^2.3.0",
+    "koa-compose": "^3.0.0",
     "ws": "^1.1.0"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -2,23 +2,23 @@
 
 var assert = require('assert'),
   WebSocket = require('ws'),
-  koa = require('koa'),
+  Koa = require('koa'),
   route = require('koa-route');
 
 var koaws = require('..');
 
 describe('should route ws messages seperately', function() {
-  var app = koaws(koa());
-  app.ws.use(route.all('/abc', function*() {
-    this.websocket.on('message', function(message) {
-      this.websocket.send(message);
-    }.bind(this));
+  var app = koaws(new Koa());
+  app.ws.use(route.all('/abc', function(ctx){
+    ctx.websocket.on('message', function(message) {
+      ctx.websocket.send(message);
+    });
   }));
 
-  app.ws.use(route.all('/def', function*() {
-    this.websocket.on('message', function(message) {
-      this.websocket.send(message);
-    }.bind(this));
+  app.ws.use(route.all('/def', function(ctx){
+    ctx.websocket.on('message', function(message) {
+      ctx.websocket.send(message);
+    });
   }));
 
   var server = app.listen();


### PR DESCRIPTION
This PR resolves issue #14. The root cause of the incompatibility appears to be koa-router 7.x using a newer version of koa-compose that doesn't function the same. I upgraded koa-compose and changed how the result of the composition was called -- it looks like explicit context passing instead of binding the context is the newer approach?

Because I couldn't seem to maintain koa 1.x compatibility, I guessed this should be a `next` kind of thing for koa-websocket.