### PR TITLE
Fix syntax highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,11 @@ app.ws.use(route.all('/test/:id', function (ctx) {
 }));
 
 app.listen(3000);
-
 ```
 
 With custom websocket options.
 
-```
+```js
 const Koa = require('koa'),
   route = require('koa-route'),
   websockify = require('koa-websocket');
@@ -58,5 +57,4 @@ app.ws.use(route.all('/', function* (ctx) {
 }));
 
 app.listen(3000);
-
 ```


### PR DESCRIPTION
This adds the missing language specifier to the markdown blocks. Tiny change.