### PR TITLE
perf: remove co, it is redundant in Koa v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const url = require('url');
 const https = require('https');
 const compose = require('koa-compose');
-const co = require('co');
 const ws = require('ws');
 
 const WebSocketServer = ws.Server;
@@ -22,7 +21,7 @@ KoaWebSocketServer.prototype.onConnection = function onConnection(socket, req) {
   socket.on('error', (err) => {
     debug('Error occurred:', err);
   });
-  const fn = co.wrap(compose(this.middleware));
+  const fn = compose(this.middleware);
 
   const context = this.app.createContext(req);
   context.websocket = socket;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/kudos/koa-websocket",
   "license": "MIT",
   "dependencies": {
-    "co": "^4.6.0",
     "debug": "^4.3.4",
     "koa-compose": "^4.1.0",
     "ws": "^8.5.0"


### PR DESCRIPTION
[Koa1 callback()](https://github.com/koajs/koa/blob/v1.x/lib/application.js#L127)

[Koa2 callback()](https://github.com/koajs/koa/blob/master/lib/application.js#L136)